### PR TITLE
Refactor toJS to recursively convert JavaScript object containing Mobx observables

### DIFF
--- a/src/api/tojs.ts
+++ b/src/api/tojs.ts
@@ -59,8 +59,12 @@ function toJSHelper(source, options: ToJSOptions, __alreadySeen: Map<any, any>) 
 
     if (isObservableValue(source)) return toJSHelper(source.get(), options!, __alreadySeen)
 
+    // Directly return the Date object itself if contained in the observable
+    if (source instanceof Date) return source
+
     // Fallback to situation if source is an ObservableObject or a plain object
     const res = cache(__alreadySeen, source, {}, options)
+    Object.setPrototypeOf(res, Object.getPrototypeOf(source))
     for (let key in source) {
         res[key] = toJSHelper(source[key], options!, __alreadySeen)
     }

--- a/test/base/tojs.js
+++ b/test/base/tojs.js
@@ -288,7 +288,7 @@ test("#285 non-mobx class instances with toJS", () => {
     // check before lazy initialization
     expect(mobx.toJS(p1)).toEqual({
         firstName: "michel",
-        lastName: nameObservable // toJS doesn't recurse into non observable objects!
+        lastName: "weststrate" // toJS will recurse into any object that may contain observable value
     })
 })
 

--- a/test/base/tojs.js
+++ b/test/base/tojs.js
@@ -155,7 +155,7 @@ test("json2", function() {
             url: "booking.com"
         }
     })
-    expect(JSON.parse(JSON.stringify(o))).toEqual({
+    expect(mobx.toJS(o)).toEqual({
         todos: [
             {
                 title: "write blog",
@@ -217,8 +217,8 @@ test("toJS handles dates", () => {
     })
 
     var b = mobx.toJS(a)
-    expect(b.d instanceof Date).toBe(true)
-    expect(a.d === b.d).toBe(true)
+    expect(b.d).toBeInstanceOf(Date)
+    expect(a.d).toEqual(b.d)
 })
 
 test("json cycles", function() {
@@ -298,9 +298,11 @@ test("verify #566 solution", () => {
     const b = mobx.observable({ x: 3 })
     const c = mobx.observable({ a: a, b: b })
 
-    expect(mobx.toJS(c).a === a).toBeTruthy() // true
-    expect(mobx.toJS(c).b !== b).toBeTruthy() // false, cloned
-    expect(mobx.toJS(c).b.x === b.x).toBeTruthy() // true, both 3
+    expect(mobx.toJS(c).a).toEqual(a)
+    expect(mobx.toJS(c).a).toBeInstanceOf(MyClass)
+    expect(mobx.isObservableObject(c.b)).toBeTruthy()
+    expect(mobx.isObservableObject(mobx.toJS(c).b)).toBeFalsy()
+    expect(mobx.toJS(c).b).toEqual(mobx.toJS(c.b))
 })
 
 test("verify already seen", () => {


### PR DESCRIPTION
* [x] Added unit tests
* [x] Updated changelog
* [x] Verified that there is no significant performance drop (`npm run perf`)
-----
Change log:
Convert plain JavaScript object recursively and all its descendants.